### PR TITLE
feat: add 'will-finish-launching'

### DIFF
--- a/core/lib/node/app.ts
+++ b/core/lib/node/app.ts
@@ -27,6 +27,14 @@ export type PathName = keyof typeof pathNameValues;
 
 export interface AppEvents extends IEventMap {
     /**
+     * Emitted when DeskGap has finished basic startup.
+     * 
+     * On Windows and Linux, the will-finish-launching event is the same as the `ready` event; on macOS,
+     * this event represents the `applicationWillFinishLaunching` notification of `NSApplication`. 
+     */
+    'will-finish-launching': [],
+
+    /**
      * Emitted when DeskGap has finished initializing.
      */
     'ready': [],
@@ -71,6 +79,16 @@ export class App extends EventEmitter<AppEvents> {
 
         this.whenReady_ = new Promise((resolve) =>{
             this.native_ = new AppNative({
+                onWillFinishLaunching: () => {
+                    try {
+                        this.trigger_('will-finish-launching');
+                    }
+                    finally {
+                        this.removeAllListeners('will-finish-launching');
+                        resolve();
+                    }
+                },
+
                 onReady: () => {
                     this.isReady_ = true;
                     if (process.platform === 'darwin') {

--- a/core/src/app/app.h
+++ b/core/src/app/app.h
@@ -13,6 +13,7 @@ namespace DeskGap {
         std::unique_ptr<Impl> impl_;
     public:
         struct EventCallbacks {
+            std::function<void()> onWillFinishLaunching;
             std::function<void()> onReady;
             std::function<void()> beforeQuit;
         };

--- a/core/src/app/app_wrap.cc
+++ b/core/src/app/app_wrap.cc
@@ -46,6 +46,9 @@ namespace DeskGap {
             Napi::Object jsCallbacks = info[0].ToObject();
             
             App::EventCallbacks callbacks {
+                [jsOnWillFinishLaunching = JSFunctionForUI::Persist(jsCallbacks.Get("onWillFinishLaunching").As<Napi::Function>())]() {
+                    jsOnWillFinishLaunching->Call();
+                },
                 [jsOnReady = JSFunctionForUI::Persist(jsCallbacks.Get("onReady").As<Napi::Function>())]() {
                     jsOnReady->Call();
                 },

--- a/core/src/gtk/app.cpp
+++ b/core/src/gtk/app.cpp
@@ -21,6 +21,7 @@ namespace DeskGap {
     }
     
     void App::Run() {
+        impl_->callbacks.onWillFinishLaunching();
     	impl_->callbacks.onReady();
     }
     

--- a/core/src/mac/app.mm
+++ b/core/src/mac/app.mm
@@ -28,6 +28,10 @@ using std::make_shared;
     return self;
 }
 
+- (void)applicationWillFinishLaunching:(NSNotification *)notification {
+    callbacks_.onWillFinishLaunching();
+}
+
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
     callbacks_.onReady();
 }

--- a/core/src/win/app.cpp
+++ b/core/src/win/app.cpp
@@ -15,6 +15,7 @@ namespace DeskGap {
         impl_->callbacks_ = std::move(callbacks);
     }
     void App::Run() {
+        impl_->callbacks_.onWillFinishLaunching();
         impl_->callbacks_.onReady();
     }
     


### PR DESCRIPTION
Add support for 'will-finish-launching': https://electronjs.org/docs/api/app#event-will-finish-launching.

For what I analysed of the code, this seems right. I'm really interested in this project. We're build a tray app and we're just using Electron because of its cross-platform flexibility but I'm feeling it as an overkill. There are some APIs you don't support yet, but I'd like to help with some 😄 