### PR TITLE
Add icon support to the Windows implementation

### DIFF
--- a/core/src/win/BrowserWindow.cpp
+++ b/core/src/win/BrowserWindow.cpp
@@ -216,11 +216,31 @@ namespace DeskGap {
     }
 
     void BrowserWindow::SetIcon(const std::optional<std::string>& iconPath) {
-        // To be implemented...
+        if (iconPath.has_value()) {
+            std::wstring wiconPath = UTF8ToWString(iconPath->c_str());
+
+            impl_->appIcon = LoadImage(nullptr, wiconPath.c_str(), IMAGE_ICON, GetSystemMetrics(SM_CXSMICON), GetSystemMetrics(SM_CYSMICON), LR_LOADFROMFILE);
+            if (impl_->appIcon != nullptr)
+            {
+                SendMessage(impl_->windowWnd, WM_SETICON, ICON_SMALL, reinterpret_cast<LPARAM>(impl_->appIcon));
+            }
+
+            impl_->windowIcon = LoadImage(nullptr, wiconPath.c_str(), IMAGE_ICON, GetSystemMetrics(SM_CXICON), GetSystemMetrics(SM_CYICON), LR_LOADFROMFILE);
+            if (impl_->windowIcon != nullptr)
+            {            
+                SendMessage(impl_->windowWnd, WM_SETICON, ICON_BIG, reinterpret_cast<LPARAM>(impl_->windowIcon));
+            }
+        }
     }
 
-
     void BrowserWindow::Destroy() {
+        if (impl_->appIcon != nullptr && impl_->windowIcon != nullptr)
+        {
+            SendMessage(impl_->windowWnd, WM_SETICON, ICON_SMALL, reinterpret_cast<LPARAM>(nullptr));
+            SendMessage(impl_->windowWnd, WM_SETICON, ICON_BIG, reinterpret_cast<LPARAM>(nullptr));
+            DeleteObject(impl_->appIcon);
+            DeleteObject(impl_->windowIcon);
+        }
         SetWindowLongPtrW(impl_->windowWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(nullptr));
         DestroyWindow(impl_->windowWnd);
     }

--- a/core/src/win/BrowserWindow_impl.h
+++ b/core/src/win/BrowserWindow_impl.h
@@ -16,6 +16,9 @@ namespace DeskGap {
 
         POINT maxTrackSize;
         POINT minTrackSize;
+
+        HANDLE appIcon {nullptr};
+        HANDLE windowIcon {nullptr};
     };
 }
 


### PR DESCRIPTION
This adds support for the icon option of BrowserWindow in Windows (loads the recommended sizes for window and taskbar based on system metrics).